### PR TITLE
Fix code scanning alert no. 23: Incorrect conversion between integer types

### DIFF
--- a/src/processes/go/ui/ProcHandleUI.go
+++ b/src/processes/go/ui/ProcHandleUI.go
@@ -817,6 +817,11 @@ func handleForm(w http.ResponseWriter, r *http.Request) {
                 renderForm(w)
                 return
             }
+            if address > ^uint64(0)>>1 {
+                lastOutput = "<p style='color:red;'>Error: Address out of range for uintptr</p>"
+                renderForm(w)
+                return
+            }
             data := args[2]
             datas, err := WriteMemory(processName, uintptr(address), data)
             fmt.Print(datas)


### PR DESCRIPTION
Fixes [https://github.com/riccio8/Offensive-defensive-tools/security/code-scanning/23](https://github.com/riccio8/Offensive-defensive-tools/security/code-scanning/23)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseUint` is within the valid range for the `uintptr` type before performing the conversion. This can be achieved by adding an upper bound check for the parsed value. Specifically, we should check that the parsed value does not exceed the maximum value that can be represented by `uintptr`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
