### PR TITLE
Fix code scanning alert no. 19: Incorrect conversion between integer types

### DIFF
--- a/src/processes/go/ui/ProcHandleUI.go
+++ b/src/processes/go/ui/ProcHandleUI.go
@@ -138,8 +138,8 @@ func FindPidByNamePowerShell(processName string) ([]int, error) {
     // `strings.TrimSpace()` removes any extra whitespace, and `strconv.Atoi()` converts strings to integers.
     for _, line := range lines {
         line = strings.TrimSpace(line)
-        if pid, err := strconv.Atoi(line); err == nil { // Convert to integer if valid.
-            pids = append(pids, pid) // Add the PID to the list of PIDs.
+        if pid, err := strconv.ParseUint(line, 10, 32); err == nil { // Convert to uint32 if valid.
+            pids = append(pids, uint32(pid)) // Add the PID to the list of PIDs.
         }
     }
 


### PR DESCRIPTION
Fixes [https://github.com/riccio8/Offensive-defensive-tools/security/code-scanning/19](https://github.com/riccio8/Offensive-defensive-tools/security/code-scanning/19)

To fix the problem, we need to ensure that the integer values parsed from the PowerShell command output are within the valid range for `uint32` before performing the conversion. This can be achieved by adding bounds checks to ensure the values are non-negative and do not exceed the maximum value for `uint32`.

The best way to fix this is to:
1. Use `strconv.ParseUint` to parse the string directly into a `uint32` value, specifying the bit size.
2. If using `strconv.Atoi`, add explicit bounds checks to ensure the parsed integer is within the valid range for `uint32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
